### PR TITLE
docs: add brew trust command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Check the [IaC guild guidelines](https://padok-team.github.io/docs-terraform-gui
 
 ```bash
 brew tap padok-team/tap
+brew trust padok-team/tap
 brew install guacamole
 ```
 


### PR DESCRIPTION
Added command to trust the padok-team tap before installation.